### PR TITLE
Updated stack naming - name clashing

### DIFF
--- a/bin/kcms-bootstrap.ts
+++ b/bin/kcms-bootstrap.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import "source-map-support/register";
-import { BootstrapStack } from '../lib/stacks/bootstrap-stack';
+import { KCMSBootstrapStack } from '../lib/stacks/bootstrap-stack';
 import { getContext, stackProps } from '../context';
 
 const app = new cdk.App();
 const context = getContext(app);
-new BootstrapStack(app, 'BootstrapStack', {}, context);
+new KCMSBootstrapStack(app, 'KCMSBootstrapStack', {}, context);

--- a/lib/stacks/bootstrap-stack.ts
+++ b/lib/stacks/bootstrap-stack.ts
@@ -8,7 +8,7 @@ import { Context } from '../../context';
 
 
 
-export class BootstrapStack extends cdk.Stack {
+export class KCMSBootstrapStack extends cdk.Stack {
 
     constructor(scope: Construct, id: string, props: cdk.StackProps, context: Context) {
         super(scope, id, props);


### PR DESCRIPTION
Updating the naming of the "BootstrapStack" as it is a common name to use, and therefore might result in name clashing with existing stacks.